### PR TITLE
fix: support a timeout of size 0

### DIFF
--- a/python_dynamodb_lock/python_dynamodb_lock.py
+++ b/python_dynamodb_lock/python_dynamodb_lock.py
@@ -391,8 +391,8 @@ class DynamoDBLockClient:
         logger.info('Trying to acquire lock for: %s, %s', partition_key, sort_key)
 
         # plug in default values as needed
-        if not retry_period: retry_period = self._heartbeat_period
-        if not retry_timeout: retry_timeout = self._lease_duration + self._heartbeat_period
+        if retry_period is None: retry_period = self._heartbeat_period
+        if retry_timeout is None: retry_timeout = self._lease_duration + self._heartbeat_period
 
         # create the "new" lock that needs to be acquired
         new_lock = DynamoDBLock(


### PR DESCRIPTION
Instances of the `timedelta` class with all zeros [are considered *Falsey*](https://github.com/python/cpython/blob/95e271b2266b8f2e7b60ede86ccf3ede4a7f83eb/Lib/datetime.py#L878-L881). This behavior causes `python-dynamodb-lock` to fall back to the default `retry_period` and `retry_timeout` not only if those parameters are passed `None` but also if passed a blank (or zero) `timedelta`. It seems to me that this is not the expected result and this PR checks against `None` explicitly to allow for the use case where a user might want to only acquire the lock if available immediately.