### PR TITLE
Adds int support for sort_key values

### DIFF
--- a/python_dynamodb_lock/python_dynamodb_lock.py
+++ b/python_dynamodb_lock/python_dynamodb_lock.py
@@ -806,7 +806,7 @@ class BaseDynamoDBLock:
         self.expiry_time = expiry_time
         self.additional_attributes = additional_attributes or {}
         # additional properties
-        self.unique_identifier = quote(partition_key) + '|' + quote(sort_key)
+        self.unique_identifier = quote(partition_key) + '|' + quote('%s' % sort_key)
 
 
     def __str__(self):


### PR DESCRIPTION
This is pertaining to issue #2342 

The only obstacle to supporting numerical sort_key values is that `quote()` expects a string as a parameter.  By only casting sort_key  to a string on line 809, we can avoid the `quote_from_bytes() expected bytes` error without changing the behavior of sort_key it other parts of the library.